### PR TITLE
feat: bitboard representation, move generation and integration

### DIFF
--- a/src/backend/bitboard.py
+++ b/src/backend/bitboard.py
@@ -1,0 +1,252 @@
+# Bitboard utilities for chess engine
+# Each bitboard is a 64-bit integer representing piece positions on the board
+# Bit 0 = a1, Bit 1 = b1, ..., Bit 7 = h1, Bit 8 = a2, ..., Bit 63 = h8
+
+# Piece types
+PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING = 0, 1, 2, 3, 4, 5
+WHITE, BLACK = 0, 1
+
+# Square mapping: (row, col) to bit index
+def square_to_bit(row, col):
+    """Convert (row, col) coordinates to bit index"""
+    return row * 8 + col
+
+def bit_to_square(bit):
+    """Convert bit index to (row, col) coordinates"""
+    return bit // 8, bit % 8
+
+# Bitboard operations
+def set_bit(bitboard, bit):
+    """Set a bit in the bitboard"""
+    return bitboard | (1 << bit)
+
+def clear_bit(bitboard, bit):
+    """Clear a bit in the bitboard"""
+    return bitboard & ~(1 << bit)
+
+def get_bit(bitboard, bit):
+    """Check if a bit is set in the bitboard"""
+    return (bitboard >> bit) & 1
+
+def pop_bit(bitboard):
+    """Remove and return the least significant bit"""
+    if bitboard == 0:
+        return 0, 0
+    bit = (bitboard & -bitboard).bit_length() - 1
+    return bit, bitboard & (bitboard - 1)
+
+def count_bits(bitboard):
+    """Count the number of set bits"""
+    return bin(bitboard).count('1')
+
+def lsb(bitboard):
+    """Get the least significant bit index"""
+    if bitboard == 0:
+        return -1
+    return (bitboard & -bitboard).bit_length() - 1
+
+# Direction constants for sliding pieces
+NORTH = 8
+SOUTH = -8
+EAST = 1
+WEST = -1
+NORTHEAST = 9
+NORTHWEST = 7
+SOUTHEAST = -7
+SOUTHWEST = -9
+
+# File and rank masks
+FILE_A = 0x0101010101010101
+FILE_B = 0x0202020202020202
+FILE_C = 0x0404040404040404
+FILE_D = 0x0808080808080808
+FILE_E = 0x1010101010101010
+FILE_F = 0x2020202020202020
+FILE_G = 0x4040404040404040
+FILE_H = 0x8080808080808080
+
+RANK_1 = 0x00000000000000FF
+RANK_2 = 0x000000000000FF00
+RANK_3 = 0x0000000000FF0000
+RANK_4 = 0x00000000FF000000
+RANK_5 = 0x000000FF00000000
+RANK_6 = 0x0000FF0000000000
+RANK_7 = 0x00FF000000000000
+RANK_8 = 0xFF00000000000000
+
+FILES = [FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H]
+RANKS = [RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8]
+
+# Edge masks (for preventing wrap-around in move generation)
+NOT_A_FILE = ~FILE_A
+NOT_H_FILE = ~FILE_H
+NOT_AB_FILE = ~(FILE_A | FILE_B)
+NOT_GH_FILE = ~(FILE_G | FILE_H)
+
+# Knight move masks
+KNIGHT_ATTACKS = [0] * 64
+def init_knight_attacks():
+    for square in range(64):
+        row, col = bit_to_square(square)
+        attacks = 0
+        
+        # Knight moves: 8 possible L-shaped moves
+        knight_moves = [
+            (-2, -1), (-2, 1), (-1, -2), (-1, 2),
+            (1, -2), (1, 2), (2, -1), (2, 1)
+        ]
+        
+        for dr, dc in knight_moves:
+            new_row, new_col = row + dr, col + dc
+            if 0 <= new_row < 8 and 0 <= new_col < 8:
+                attacks = set_bit(attacks, square_to_bit(new_row, new_col))
+        
+        KNIGHT_ATTACKS[square] = attacks
+
+# King move masks
+KING_ATTACKS = [0] * 64
+def init_king_attacks():
+    for square in range(64):
+        row, col = bit_to_square(square)
+        attacks = 0
+        
+        # King moves: 8 directions
+        for dr in [-1, 0, 1]:
+            for dc in [-1, 0, 1]:
+                if dr == 0 and dc == 0:
+                    continue
+                new_row, new_col = row + dr, col + dc
+                if 0 <= new_row < 8 and 0 <= new_col < 8:
+                    attacks = set_bit(attacks, square_to_bit(new_row, new_col))
+        
+        KING_ATTACKS[square] = attacks
+
+# Pawn attack masks
+WHITE_PAWN_ATTACKS = [0] * 64
+BLACK_PAWN_ATTACKS = [0] * 64
+
+def init_pawn_attacks():
+    for square in range(64):
+        row, col = bit_to_square(square)
+        
+        # White pawn attacks (moving up the board, decreasing row)
+        white_attacks = 0
+        if row > 0:  # Not on first rank
+            if col > 0:  # Can attack left
+                white_attacks = set_bit(white_attacks, square_to_bit(row - 1, col - 1))
+            if col < 7:  # Can attack right
+                white_attacks = set_bit(white_attacks, square_to_bit(row - 1, col + 1))
+        WHITE_PAWN_ATTACKS[square] = white_attacks
+        
+        # Black pawn attacks (moving down the board, increasing row)
+        black_attacks = 0
+        if row < 7:  # Not on last rank
+            if col > 0:  # Can attack left
+                black_attacks = set_bit(black_attacks, square_to_bit(row + 1, col - 1))
+            if col < 7:  # Can attack right
+                black_attacks = set_bit(black_attacks, square_to_bit(row + 1, col + 1))
+        BLACK_PAWN_ATTACKS[square] = black_attacks
+
+# Sliding piece attack generation
+def get_rook_attacks(square, occupancy):
+    """Generate rook attacks for a given square and occupancy"""
+    attacks = 0
+    row, col = bit_to_square(square)
+    
+    # North
+    for r in range(row - 1, -1, -1):
+        bit = square_to_bit(r, col)
+        attacks = set_bit(attacks, bit)
+        if get_bit(occupancy, bit):
+            break
+    
+    # South
+    for r in range(row + 1, 8):
+        bit = square_to_bit(r, col)
+        attacks = set_bit(attacks, bit)
+        if get_bit(occupancy, bit):
+            break
+    
+    # West
+    for c in range(col - 1, -1, -1):
+        bit = square_to_bit(row, c)
+        attacks = set_bit(attacks, bit)
+        if get_bit(occupancy, bit):
+            break
+    
+    # East
+    for c in range(col + 1, 8):
+        bit = square_to_bit(row, c)
+        attacks = set_bit(attacks, bit)
+        if get_bit(occupancy, bit):
+            break
+    
+    return attacks
+
+def get_bishop_attacks(square, occupancy):
+    """Generate bishop attacks for a given square and occupancy"""
+    attacks = 0
+    row, col = bit_to_square(square)
+    
+    # Northeast
+    r, c = row - 1, col + 1
+    while r >= 0 and c < 8:
+        bit = square_to_bit(r, c)
+        attacks = set_bit(attacks, bit)
+        if get_bit(occupancy, bit):
+            break
+        r -= 1
+        c += 1
+    
+    # Northwest
+    r, c = row - 1, col - 1
+    while r >= 0 and c >= 0:
+        bit = square_to_bit(r, c)
+        attacks = set_bit(attacks, bit)
+        if get_bit(occupancy, bit):
+            break
+        r -= 1
+        c -= 1
+    
+    # Southeast
+    r, c = row + 1, col + 1
+    while r < 8 and c < 8:
+        bit = square_to_bit(r, c)
+        attacks = set_bit(attacks, bit)
+        if get_bit(occupancy, bit):
+            break
+        r += 1
+        c += 1
+    
+    # Southwest
+    r, c = row + 1, col - 1
+    while r < 8 and c >= 0:
+        bit = square_to_bit(r, c)
+        attacks = set_bit(attacks, bit)
+        if get_bit(occupancy, bit):
+            break
+        r += 1
+        c -= 1
+    
+    return attacks
+
+def get_queen_attacks(square, occupancy):
+    """Generate queen attacks (combination of rook and bishop)"""
+    return get_rook_attacks(square, occupancy) | get_bishop_attacks(square, occupancy)
+
+# Initialize attack tables
+init_knight_attacks()
+init_king_attacks()
+init_pawn_attacks()
+
+def print_bitboard(bitboard):
+    """Print a bitboard in a readable 8x8 format"""
+    for row in range(8):
+        for col in range(8):
+            bit = square_to_bit(row, col)
+            if get_bit(bitboard, bit):
+                print("1 ", end="")
+            else:
+                print("0 ", end="")
+        print()
+    print()

--- a/src/backend/board.py
+++ b/src/backend/board.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
+from .bitboard import *
 
 
 @dataclass
@@ -11,6 +12,7 @@ class MoveRecord:
     to_sq: Tuple[int, int] = (0, 0)
 
 
+# Legacy piece constants for backward compatibility
 EMPTY = 0
 WPAWN, WKNIGHT, WBISHOP, WROOK, WQUEEN, WKING = 1, 2, 3, 4, 5, 6
 BPAWN, BKNIGHT, BBISHOP, BROOK, BQUEEN, BKING = -1, -2, -3, -4, -5, -6
@@ -18,61 +20,202 @@ BPAWN, BKNIGHT, BBISHOP, BROOK, BQUEEN, BKING = -1, -2, -3, -4, -5, -6
 
 class Board:
     def __init__(self):
-        self.board = self.starting_pos()
+        # Bitboards for each piece type and color
+        # Index: [WHITE/BLACK][PIECE_TYPE]
+        self.piece_bitboards = [[0 for _ in range(6)] for _ in range(2)]
+        self.color_bitboards = [0, 0]  # [WHITE, BLACK]
+        self.all_pieces = 0
+        
+        # King positions for quick access
         self.wking_pos = (7, 4)
         self.bking_pos = (0, 4)
+        
+        self.init_starting_position()
+
+    def init_starting_position(self):
+        """Initialize the starting chess position using bitboards"""
+        # Clear all bitboards
+        self.piece_bitboards = [[0 for _ in range(6)] for _ in range(2)]
+        self.color_bitboards = [0, 0]
+        self.all_pieces = 0
+        
+        # Set up white pieces
+        self.piece_bitboards[WHITE][ROOK] = set_bit(self.piece_bitboards[WHITE][ROOK], square_to_bit(7, 0))  # a1
+        self.piece_bitboards[WHITE][ROOK] = set_bit(self.piece_bitboards[WHITE][ROOK], square_to_bit(7, 7))  # h1
+        self.piece_bitboards[WHITE][KNIGHT] = set_bit(self.piece_bitboards[WHITE][KNIGHT], square_to_bit(7, 1))  # b1
+        self.piece_bitboards[WHITE][KNIGHT] = set_bit(self.piece_bitboards[WHITE][KNIGHT], square_to_bit(7, 6))  # g1
+        self.piece_bitboards[WHITE][BISHOP] = set_bit(self.piece_bitboards[WHITE][BISHOP], square_to_bit(7, 2))  # c1
+        self.piece_bitboards[WHITE][BISHOP] = set_bit(self.piece_bitboards[WHITE][BISHOP], square_to_bit(7, 5))  # f1
+        self.piece_bitboards[WHITE][QUEEN] = set_bit(self.piece_bitboards[WHITE][QUEEN], square_to_bit(7, 3))  # d1
+        self.piece_bitboards[WHITE][KING] = set_bit(self.piece_bitboards[WHITE][KING], square_to_bit(7, 4))  # e1
+        
+        # White pawns
+        for col in range(8):
+            self.piece_bitboards[WHITE][PAWN] = set_bit(self.piece_bitboards[WHITE][PAWN], square_to_bit(6, col))
+        
+        # Set up black pieces
+        self.piece_bitboards[BLACK][ROOK] = set_bit(self.piece_bitboards[BLACK][ROOK], square_to_bit(0, 0))  # a8
+        self.piece_bitboards[BLACK][ROOK] = set_bit(self.piece_bitboards[BLACK][ROOK], square_to_bit(0, 7))  # h8
+        self.piece_bitboards[BLACK][KNIGHT] = set_bit(self.piece_bitboards[BLACK][KNIGHT], square_to_bit(0, 1))  # b8
+        self.piece_bitboards[BLACK][KNIGHT] = set_bit(self.piece_bitboards[BLACK][KNIGHT], square_to_bit(0, 6))  # g8
+        self.piece_bitboards[BLACK][BISHOP] = set_bit(self.piece_bitboards[BLACK][BISHOP], square_to_bit(0, 2))  # c8
+        self.piece_bitboards[BLACK][BISHOP] = set_bit(self.piece_bitboards[BLACK][BISHOP], square_to_bit(0, 5))  # f8
+        self.piece_bitboards[BLACK][QUEEN] = set_bit(self.piece_bitboards[BLACK][QUEEN], square_to_bit(0, 3))  # d8
+        self.piece_bitboards[BLACK][KING] = set_bit(self.piece_bitboards[BLACK][KING], square_to_bit(0, 4))  # e8
+        
+        # Black pawns
+        for col in range(8):
+            self.piece_bitboards[BLACK][PAWN] = set_bit(self.piece_bitboards[BLACK][PAWN], square_to_bit(1, col))
+        
+        # Update combined bitboards
+        self.update_combined_bitboards()
+
+    def update_combined_bitboards(self):
+        """Update the combined color and all-pieces bitboards"""
+        self.color_bitboards[WHITE] = 0
+        self.color_bitboards[BLACK] = 0
+        
+        for piece_type in range(6):
+            self.color_bitboards[WHITE] |= self.piece_bitboards[WHITE][piece_type]
+            self.color_bitboards[BLACK] |= self.piece_bitboards[BLACK][piece_type]
+        
+        self.all_pieces = self.color_bitboards[WHITE] | self.color_bitboards[BLACK]
+
+    def get_piece_at(self, row, col):
+        """Get the piece at a given square (for backward compatibility)"""
+        bit = square_to_bit(row, col)
+        
+        if not get_bit(self.all_pieces, bit):
+            return EMPTY
+        
+        # Check which piece is at this square
+        for color in [WHITE, BLACK]:
+            if get_bit(self.color_bitboards[color], bit):
+                for piece_type in range(6):
+                    if get_bit(self.piece_bitboards[color][piece_type], bit):
+                        # Convert to legacy piece values
+                        piece_value = piece_type + 1
+                        return piece_value if color == WHITE else -piece_value
+        
+        return EMPTY
 
     def starting_pos(self):
-        return [
-            [BROOK, BKNIGHT, BBISHOP, BQUEEN, BKING, BBISHOP, BKNIGHT, BROOK],
-            [BPAWN, BPAWN, BPAWN, BPAWN, BPAWN, BPAWN, BPAWN, BPAWN],
-            [EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY],
-            [EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY],
-            [EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY],
-            [EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY, EMPTY],
-            [WPAWN, WPAWN, WPAWN, WPAWN, WPAWN, WPAWN, WPAWN, WPAWN],
-            [WROOK, WKNIGHT, WBISHOP, WQUEEN, WKING, WBISHOP, WKNIGHT, WROOK],
-        ]
+        """Return an 8x8 array representation for backward compatibility"""
+        board = []
+        for row in range(8):
+            row_pieces = []
+            for col in range(8):
+                row_pieces.append(self.get_piece_at(row, col))
+            board.append(row_pieces)
+        return board
+
+    @property
+    def board(self):
+        """Property to maintain backward compatibility with the 8x8 array interface"""
+        return self.starting_pos()
 
     def apply_move(self, move):
+        """Apply a move to the board and return a record for undoing"""
         (fx, fy), (tx, ty) = move
-
-        original_piece = self.board[fx][fy]
-
-        captured = self.board[tx][ty]
-
-        self.board[tx][ty] = original_piece
-        self.board[fx][fy] = EMPTY
-
-        if original_piece == WKING:
+        
+        from_bit = square_to_bit(fx, fy)
+        to_bit = square_to_bit(tx, ty)
+        
+        # Find the piece being moved
+        moved_piece_legacy = self.get_piece_at(fx, fy)
+        captured_piece_legacy = self.get_piece_at(tx, ty)
+        
+        if moved_piece_legacy == EMPTY:
+            raise ValueError(f"No piece at source square ({fx}, {fy})")
+        
+        # Convert legacy piece to color and type
+        is_white = moved_piece_legacy > 0
+        color = WHITE if is_white else BLACK
+        piece_type = abs(moved_piece_legacy) - 1
+        
+        # Remove piece from source square
+        self.piece_bitboards[color][piece_type] = clear_bit(self.piece_bitboards[color][piece_type], from_bit)
+        
+        # If there's a captured piece, remove it
+        if captured_piece_legacy != EMPTY:
+            captured_color = WHITE if captured_piece_legacy > 0 else BLACK
+            captured_piece_type = abs(captured_piece_legacy) - 1
+            self.piece_bitboards[captured_color][captured_piece_type] = clear_bit(
+                self.piece_bitboards[captured_color][captured_piece_type], to_bit
+            )
+        
+        # Place piece on destination square
+        self.piece_bitboards[color][piece_type] = set_bit(self.piece_bitboards[color][piece_type], to_bit)
+        
+        # Update king positions
+        if moved_piece_legacy == WKING:
             self.wking_pos = (tx, ty)
-        elif original_piece == BKING:
+        elif moved_piece_legacy == BKING:
             self.bking_pos = (tx, ty)
-
+        
+        # Handle pawn promotion
         promotion = None
-        if original_piece == WPAWN and tx == 0:
-            promotion = WQUEEN
-            self.board[tx][ty] = WQUEEN
-        elif original_piece == BPAWN and tx == 7:
-            promotion = BQUEEN
-            self.board[tx][ty] = BQUEEN
-
+        if abs(moved_piece_legacy) == WPAWN:
+            if (moved_piece_legacy == WPAWN and tx == 0) or (moved_piece_legacy == BPAWN and tx == 7):
+                # Remove pawn and add queen
+                self.piece_bitboards[color][PAWN] = clear_bit(self.piece_bitboards[color][PAWN], to_bit)
+                self.piece_bitboards[color][QUEEN] = set_bit(self.piece_bitboards[color][QUEEN], to_bit)
+                promotion = WQUEEN if is_white else BQUEEN
+        
+        # Update combined bitboards
+        self.update_combined_bitboards()
+        
         return MoveRecord(
-            moved_piece=original_piece,
-            captured_piece=captured,
+            moved_piece=moved_piece_legacy,
+            captured_piece=captured_piece_legacy,
             promotion=promotion,
             from_sq=(fx, fy),
             to_sq=(tx, ty),
         )
 
     def undo_move(self, move, move_record):
+        """Undo a move using the move record"""
         (fx, fy), (tx, ty) = move
-        # piece = self.board[tx][ty]
-
-        self.board[fx][fy] = move_record.moved_piece
-        self.board[tx][ty] = move_record.captured_piece
-
-        if move_record.moved_piece == WKING:
+        
+        from_bit = square_to_bit(fx, fy)
+        to_bit = square_to_bit(tx, ty)
+        
+        moved_piece_legacy = move_record.moved_piece
+        captured_piece_legacy = move_record.captured_piece
+        
+        # Convert legacy piece to color and type
+        is_white = moved_piece_legacy > 0
+        color = WHITE if is_white else BLACK
+        piece_type = abs(moved_piece_legacy) - 1
+        
+        # Handle promotion undo
+        if move_record.promotion:
+            # Remove promoted piece and restore pawn
+            self.piece_bitboards[color][QUEEN] = clear_bit(self.piece_bitboards[color][QUEEN], to_bit)
+            self.piece_bitboards[color][PAWN] = set_bit(self.piece_bitboards[color][PAWN], to_bit)
+        
+        # Remove piece from destination square
+        current_piece_type = PAWN if move_record.promotion else piece_type
+        self.piece_bitboards[color][current_piece_type] = clear_bit(
+            self.piece_bitboards[color][current_piece_type], to_bit
+        )
+        
+        # Restore piece to source square
+        self.piece_bitboards[color][piece_type] = set_bit(self.piece_bitboards[color][piece_type], from_bit)
+        
+        # Restore captured piece if any
+        if captured_piece_legacy != EMPTY:
+            captured_color = WHITE if captured_piece_legacy > 0 else BLACK
+            captured_piece_type = abs(captured_piece_legacy) - 1
+            self.piece_bitboards[captured_color][captured_piece_type] = set_bit(
+                self.piece_bitboards[captured_color][captured_piece_type], to_bit
+            )
+        
+        # Restore king positions
+        if moved_piece_legacy == WKING:
             self.wking_pos = (fx, fy)
-        elif move_record.moved_piece == BKING:
+        elif moved_piece_legacy == BKING:
             self.bking_pos = (fx, fy)
+        
+        # Update combined bitboards
+        self.update_combined_bitboards()

--- a/src/backend/game.py
+++ b/src/backend/game.py
@@ -1,6 +1,7 @@
 from .board import Board
 # import random
-from .move_gen import getLegalMoves, isSquareAttacked
+# from .move_gen import getLegalMoves, isSquareAttacked
+from .move_gen_bb import isSquareAttacked, getLegalMoves
 
 
 class Game:

--- a/src/backend/move_gen_bb.py
+++ b/src/backend/move_gen_bb.py
@@ -1,0 +1,266 @@
+# Bitboard-based move generation
+from .bitboard import *
+from .board import WPAWN, WKNIGHT, WBISHOP, WROOK, WQUEEN, WKING
+from .board import BPAWN, BKNIGHT, BBISHOP, BROOK, BQUEEN, BKING, EMPTY
+
+
+def generate_pawn_moves(board, color):
+    """Generate all pawn moves for the given color"""
+    moves = []
+    pawn_bb = board.piece_bitboards[color][PAWN]
+    
+    if color == WHITE:
+        # White pawns move "up" (decreasing row numbers)
+        # Single pawn push
+        single_push = (pawn_bb >> 8) & ~board.all_pieces
+        
+        # Double pawn push (from starting rank)
+        double_push = ((single_push & RANK_6) >> 8) & ~board.all_pieces
+        
+        # Pawn attacks
+        attacks_left = (pawn_bb >> 7) & ~FILE_A & board.color_bitboards[BLACK]
+        attacks_right = (pawn_bb >> 9) & ~FILE_H & board.color_bitboards[BLACK]
+        
+        # Convert moves to coordinate format
+        while single_push:
+            to_bit, single_push = pop_bit(single_push)
+            from_bit = to_bit + 8
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+        
+        while double_push:
+            to_bit, double_push = pop_bit(double_push)
+            from_bit = to_bit + 16
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+        
+        while attacks_left:
+            to_bit, attacks_left = pop_bit(attacks_left)
+            from_bit = to_bit + 7
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+        
+        while attacks_right:
+            to_bit, attacks_right = pop_bit(attacks_right)
+            from_bit = to_bit + 9
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+    
+    else:  # BLACK
+        # Black pawns move "down" (increasing row numbers)
+        # Single pawn push
+        single_push = (pawn_bb << 8) & ~board.all_pieces
+        
+        # Double pawn push (from starting rank)
+        double_push = ((single_push & RANK_3) << 8) & ~board.all_pieces
+        
+        # Pawn attacks
+        attacks_left = (pawn_bb << 9) & ~FILE_A & board.color_bitboards[WHITE]
+        attacks_right = (pawn_bb << 7) & ~FILE_H & board.color_bitboards[WHITE]
+        
+        # Convert moves to coordinate format
+        while single_push:
+            to_bit, single_push = pop_bit(single_push)
+            from_bit = to_bit - 8
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+        
+        while double_push:
+            to_bit, double_push = pop_bit(double_push)
+            from_bit = to_bit - 16
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+        
+        while attacks_left:
+            to_bit, attacks_left = pop_bit(attacks_left)
+            from_bit = to_bit - 9
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+        
+        while attacks_right:
+            to_bit, attacks_right = pop_bit(attacks_right)
+            from_bit = to_bit - 7
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+    
+    return moves
+
+
+def generate_knight_moves(board, color):
+    """Generate all knight moves for the given color"""
+    moves = []
+    knight_bb = board.piece_bitboards[color][KNIGHT]
+    own_pieces = board.color_bitboards[color]
+    
+    while knight_bb:
+        from_bit, knight_bb = pop_bit(knight_bb)
+        attacks = KNIGHT_ATTACKS[from_bit] & ~own_pieces
+        
+        while attacks:
+            to_bit, attacks = pop_bit(attacks)
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+    
+    return moves
+
+
+def generate_bishop_moves(board, color):
+    """Generate all bishop moves for the given color"""
+    moves = []
+    bishop_bb = board.piece_bitboards[color][BISHOP]
+    own_pieces = board.color_bitboards[color]
+    
+    while bishop_bb:
+        from_bit, bishop_bb = pop_bit(bishop_bb)
+        attacks = get_bishop_attacks(from_bit, board.all_pieces) & ~own_pieces
+        
+        while attacks:
+            to_bit, attacks = pop_bit(attacks)
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+    
+    return moves
+
+
+def generate_rook_moves(board, color):
+    """Generate all rook moves for the given color"""
+    moves = []
+    rook_bb = board.piece_bitboards[color][ROOK]
+    own_pieces = board.color_bitboards[color]
+    
+    while rook_bb:
+        from_bit, rook_bb = pop_bit(rook_bb)
+        attacks = get_rook_attacks(from_bit, board.all_pieces) & ~own_pieces
+        
+        while attacks:
+            to_bit, attacks = pop_bit(attacks)
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+    
+    return moves
+
+
+def generate_queen_moves(board, color):
+    """Generate all queen moves for the given color"""
+    moves = []
+    queen_bb = board.piece_bitboards[color][QUEEN]
+    own_pieces = board.color_bitboards[color]
+    
+    while queen_bb:
+        from_bit, queen_bb = pop_bit(queen_bb)
+        attacks = get_queen_attacks(from_bit, board.all_pieces) & ~own_pieces
+        
+        while attacks:
+            to_bit, attacks = pop_bit(attacks)
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+    
+    return moves
+
+
+def generate_king_moves(board, color):
+    """Generate all king moves for the given color"""
+    moves = []
+    king_bb = board.piece_bitboards[color][KING]
+    own_pieces = board.color_bitboards[color]
+    
+    if king_bb:
+        from_bit = lsb(king_bb)  # King is unique, so just get its position
+        attacks = KING_ATTACKS[from_bit] & ~own_pieces
+        
+        while attacks:
+            to_bit, attacks = pop_bit(attacks)
+            moves.append((bit_to_square(from_bit), bit_to_square(to_bit)))
+    
+    return moves
+
+
+def generate_pseudo_legal_moves(board, color):
+    """Generate all pseudo-legal moves for the given color"""
+    moves = []
+    
+    moves.extend(generate_pawn_moves(board, color))
+    moves.extend(generate_knight_moves(board, color))
+    moves.extend(generate_bishop_moves(board, color))
+    moves.extend(generate_rook_moves(board, color))
+    moves.extend(generate_queen_moves(board, color))
+    moves.extend(generate_king_moves(board, color))
+    
+    return moves
+
+
+def is_square_attacked_bb(board, square, by_color):
+    """Check if a square is attacked by pieces of the given color using bitboards"""
+    row, col = square
+    target_bit = square_to_bit(row, col)
+    
+    # Check pawn attacks
+    if by_color == WHITE:
+        # White pawns attack diagonally "up" (from higher row numbers to lower)
+        if target_bit < 56:  # Not on rank 8
+            # Check if white pawns can attack this square
+            pawn_attack_sources = 0
+            if col > 0:  # Left attack (from pawn's perspective)
+                pawn_attack_sources |= (1 << (target_bit + 7))
+            if col < 7:  # Right attack (from pawn's perspective)
+                pawn_attack_sources |= (1 << (target_bit + 9))
+            
+            if board.piece_bitboards[WHITE][PAWN] & pawn_attack_sources:
+                return True
+    else:  # BLACK
+        # Black pawns attack diagonally "down" (from lower row numbers to higher)
+        if target_bit >= 8:  # Not on rank 1
+            # Check if black pawns can attack this square
+            pawn_attack_sources = 0
+            if col > 0:  # Left attack (from pawn's perspective)
+                pawn_attack_sources |= (1 << (target_bit - 9))
+            if col < 7:  # Right attack (from pawn's perspective)
+                pawn_attack_sources |= (1 << (target_bit - 7))
+            
+            if board.piece_bitboards[BLACK][PAWN] & pawn_attack_sources:
+                return True
+    
+    # Check knight attacks
+    knight_attacks = KNIGHT_ATTACKS[target_bit]
+    if board.piece_bitboards[by_color][KNIGHT] & knight_attacks:
+        return True
+    
+    # Check bishop/queen diagonal attacks
+    bishop_attacks = get_bishop_attacks(target_bit, board.all_pieces)
+    if (board.piece_bitboards[by_color][BISHOP] | board.piece_bitboards[by_color][QUEEN]) & bishop_attacks:
+        return True
+    
+    # Check rook/queen straight attacks
+    rook_attacks = get_rook_attacks(target_bit, board.all_pieces)
+    if (board.piece_bitboards[by_color][ROOK] | board.piece_bitboards[by_color][QUEEN]) & rook_attacks:
+        return True
+    
+    # Check king attacks
+    king_attacks = KING_ATTACKS[target_bit]
+    if board.piece_bitboards[by_color][KING] & king_attacks:
+        return True
+    
+    return False
+
+
+def get_legal_moves_bb(board, color):
+    """Generate all legal moves for the given color using bitboards"""
+    pseudo_legal = generate_pseudo_legal_moves(board, color)
+    legal_moves = []
+    
+    for move in pseudo_legal:
+        # Apply the move
+        record = board.apply_move(move)
+        
+        # Check if the king is in check after the move
+        king_pos = board.wking_pos if color == WHITE else board.bking_pos
+        enemy_color = BLACK if color == WHITE else WHITE
+        
+        if not is_square_attacked_bb(board, king_pos, enemy_color):
+            legal_moves.append(move)
+        
+        # Undo the move
+        board.undo_move(move, record)
+    
+    return legal_moves
+
+
+# Legacy compatibility functions
+def isSquareAttacked(board, x, y, by_white):
+    """Legacy function for backward compatibility"""
+    by_color = WHITE if by_white else BLACK
+    return is_square_attacked_bb(board, (x, y), by_color)
+
+
+def getLegalMoves(board, color):
+    """Legacy function for backward compatibility"""
+    color_index = WHITE if color == "white" else BLACK
+    return get_legal_moves_bb(board, color_index)


### PR DESCRIPTION
This pull request refactors the chess engine's board representation to use bitboards for piece positions and move generation, replacing the previous 8x8 array-based approach. The changes introduce a new `bitboard.py` utility module, update the `Board` class to use bitboards for state and move application, and adapt related imports for compatibility with bitboard-based move generation. Legacy interfaces are preserved for backward compatibility.

### Bitboard infrastructure and utilities

* Added a new `src/backend/bitboard.py` module implementing bitboard utilities, constants, square/bit conversions, attack masks for all piece types, and sliding piece attack generation functions. This module provides the foundational bitboard operations for the engine.

### Board representation and move logic

* Refactored the `Board` class in `src/backend/board.py` to use bitboards for piece and color tracking, move application, undo logic, and starting position initialization. Legacy 8x8 array interfaces and piece constants are maintained for compatibility.
* Updated the move application and undo logic in `Board` to operate on bitboards, including handling of promotions and king position updates.

### Integration and compatibility

* Updated imports in `src/backend/board.py` and `src/backend/game.py` to use the new bitboard utilities and the bitboard-based move generation functions, ensuring the engine uses the new representation throughout. [[1]](diffhunk://#diff-6885d8d0470ef55ae61ddf43f6e4642c7049a99890b6eda803baa6b89f3c2314R3) [[2]](diffhunk://#diff-bad510a182e46c426d9a27b45039da6038e95211157c4e684d6553ca7aa5abebL3-R4)

Resolving issue #7 