### PR TITLE
En passant implementation

### DIFF
--- a/src/backend/board.py
+++ b/src/backend/board.py
@@ -9,6 +9,7 @@ class MoveRecord:
     promotion: Optional[int] = None
     from_sq: Tuple[int, int] = (0, 0)
     to_sq: Tuple[int, int] = (0, 0)
+    en_passant: bool = False 
 
 
 EMPTY = 0
@@ -44,11 +45,19 @@ class Board:
         self.board[tx][ty] = original_piece
         self.board[fx][fy] = EMPTY
 
+        en_passant = False
+
         if original_piece == WKING:
             self.wking_pos = (tx, ty)
         elif original_piece == BKING:
             self.bking_pos = (tx, ty)
-
+        
+        # HANDLE EN PASSANT
+        elif captured == EMPTY and abs(original_piece) == WPAWN:
+            if fy != ty:
+                captured = self.board[tx + abs(original_piece)][ty]
+                self.board[tx + abs(original_piece)][ty] = EMPTY
+                en_passant = True
         # HANDLE CASTLING
         # CHECK IF KING MADE A 2SQR MOVE
         if abs(original_piece) == WKING and abs(fy - ty) == 2:
@@ -77,6 +86,7 @@ class Board:
             promotion=promotion,
             from_sq=(fx, fy),
             to_sq=(tx, ty),
+            en_passant=en_passant
         )
 
     def undo_move(self, move, move_record):
@@ -102,3 +112,9 @@ class Board:
                 rook = self.board[fx][3]
                 self.board[fx][0] = rook  # nudo rook
                 self.board[fx][3] = EMPTY
+
+        # ENPASSANT UNDO
+        elif move_record.en_passant:
+            self.board[tx][ty] = EMPTY;
+            self.board[tx + abs(move_record.moved_piece)][ty] = move_record.captured_piece;
+                        

--- a/src/backend/move_gen.py
+++ b/src/backend/move_gen.py
@@ -88,12 +88,13 @@ def getEnPassantMoves(board, color, history):
         lastMove.moved_piece == enemyPawn 
         and lastMove.to_sq[0] == row 
         and lastMove.from_sq[0] == enemyPawnStart
+        and board[endingRow][lastMove.to_sq[1]] == EMPTY 
     ): 
         # Get adjacent player pawns
         cols = (lastMove.to_sq[1] - 1, lastMove.to_sq[1] + 1) 
         for col in cols:
             if in_bounds(row, col) and board.board[row][col] == pawn:
-                moves.append(((row, col), (endingRow, lastMove.to_sq[1])))
+                moves.append(((row, col), [endingRow][lastMove.to_sq[1]] ))
     return moves
 
 def canCastle(board, color, side, history):

--- a/src/backend/move_gen.py
+++ b/src/backend/move_gen.py
@@ -165,6 +165,7 @@ def getLegalMoves(board, color, history):
 
             for nx, ny in getPseudoLegalMoves(board.board, x, y):
                 move = ((x, y), (nx, ny))
+                 
                 record = board.apply_move(move)
 
                 king_pos = board.wking_pos if color == "white" else board.bking_pos
@@ -172,6 +173,17 @@ def getLegalMoves(board, color, history):
                     moves.append(move)
 
                 board.undo_move(move, record)
+
+    # EN PASSANT LOGIC
+    
+    for move in getEnPassantMoves(board, color, history):
+        record = board.apply_move(move)
+
+        king_pos = board.wking_pos if color == "white" else board.bking_pos
+        if not isSquareAttacked(board, *king_pos, by_white=(color == "black")):
+            moves.append(move)
+
+        board.undo_move(move, record)
 
     # CASTLING LOGIC
 

--- a/src/backend/move_gen.py
+++ b/src/backend/move_gen.py
@@ -71,6 +71,31 @@ def isSquareAttacked(board, x, y, by_white):
     return False
 
 
+def getEnPassantMoves(board, color, history): 
+    if not history:
+        return []
+
+    row = 4 if color == "white" else 3 
+    endingRow = row + 1 if color == "white" else row - 1
+    enemyPawnStart = 6 if color == "white" else 1  
+    enemyPawn = BPAWN if color == "white" else WPAWN
+    pawn = WPAWN if color == "white" else BPAWN
+    moves = []
+
+    # check last move was double pawn move
+    lastMove = history[-1]
+    if (
+        lastMove.moved_piece == enemyPawn 
+        and lastMove.to_sq[0] == row 
+        and lastMove.from_sq[0] == enemyPawnStart
+    ): 
+        # Get adjacent player pawns
+        cols = (lastMove.to_sq[1] - 1, lastMove.to_sq[1] + 1) 
+        for col in cols:
+            if in_bounds(row, col) and board.board[row][col] == pawn:
+                moves.append(((row, col), (endingRow, lastMove.to_sq[1])))
+    return moves
+
 def canCastle(board, color, side, history):
     row = 7 if color == "white" else 0
     king = WKING if color == "white" else BKING

--- a/src/backend/move_gen.py
+++ b/src/backend/move_gen.py
@@ -75,9 +75,9 @@ def getEnPassantMoves(board, color, history):
     if not history:
         return []
 
-    row = 4 if color == "white" else 3 
-    endingRow = row + 1 if color == "white" else row - 1
-    enemyPawnStart = 6 if color == "white" else 1  
+    row = 3 if color == "white" else 4 
+    endingRow = row - 1 if color == "white" else row + 1
+    enemyPawnStart = 1 if color == "white" else 6  
     enemyPawn = BPAWN if color == "white" else WPAWN
     pawn = WPAWN if color == "white" else BPAWN
     moves = []
@@ -93,8 +93,8 @@ def getEnPassantMoves(board, color, history):
         # Get adjacent player pawns
         cols = (lastMove.to_sq[1] - 1, lastMove.to_sq[1] + 1) 
         for col in cols:
-            if in_bounds(row, col) and board.board[row][col] == pawn:
-                moves.append(((row, col), [endingRow][lastMove.to_sq[1]] ))
+            if in_bounds(row, col) and board[row][col] == pawn:
+                moves.append(((row, col), (endingRow, lastMove.to_sq[1])))
     return moves
 
 def canCastle(board, color, side, history):
@@ -177,7 +177,7 @@ def getLegalMoves(board, color, history):
 
     # EN PASSANT LOGIC
     
-    for move in getEnPassantMoves(board, color, history):
+    for move in getEnPassantMoves(board.board, color, history):
         record = board.apply_move(move)
 
         king_pos = board.wking_pos if color == "white" else board.bking_pos


### PR DESCRIPTION
Implemented valid, efficient en passant move generation and validation.
### **Pseudocode**
****
**Move Generation**
1.  Check if most recent move in game history was a double pawn move
2.  Scan the enemy pawn's adjacent (in bound) squares for player pawns (No additional unnecessary looping)
3.  Check that the square behind enemy pawn is empty
4.  Apply each of the en passant moves, ensure that player king is not placed in check, then undo and add to legal moves

**Applying Move**
1. If current move is a diagonal pawn move, and the target square is empty, we know that is an en passant move.
2.  Set captured to the pawn 1 row above/below (white and black player respectively) and empty the square
3.  Set en_passant field in move record to True

**Undo Move**
1. Check move record has en_passant field to true.
2.  Set destination square to empty.
3. Place enemy pawn 1 row above/below (white and black player respectively)
### Changes
****

- New function in move_gen.py getEnPassantMoves() for generating en passant moves
-  Branch in getLegalMoves for adding valid en passant moves to legal moves
-  Branch in Board.apply_move() for applying en passant moves
-  Branch in Board.undo_move() for undoing en passant moves
- **Added en_passant boolean field to MoveRecord class initialised to false** 
### **Example: (en passant shown move 34)**
<img width="250" height="249" alt="ss1" src="https://github.com/user-attachments/assets/62f22bd6-0d92-4c1f-b5d9-b640ac67e202" /> <img width="216" height="249" alt="ss2" src="https://github.com/user-attachments/assets/4cbc3795-1e2c-409c-9de1-61f4785f12fc" />
