### PR TITLE
feat: draw by threefold repetition with Zobrist hashing

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,21 @@ move_number = 1
 
 last_engine_move = None
 
+
+def prompt_draw():
+    while True:
+        try:
+            choice = input("Threefold repetition detected. Claim draw? (y/n): ")
+            if choice == "y":
+                api.claim_threefold_draw()
+                break
+            if choice == "n":
+                break
+            print("Invalid choice, try again.")
+        except:
+            print("Invalid input, enter a number.")
+
+
 while not api.get_state()["over"]:
     state = api.get_state()
 
@@ -19,6 +34,13 @@ while not api.get_state()["over"]:
         print(f"Last Engine Move: {last_engine_move}")
 
     if state["turn"] == "white":
+
+        # LET PLAYER CLAIM DRAW ON 3RD REPETITION
+        if state["result"] == "threefold_draw_claimable":
+            prompt_draw()
+        if api.get_state()["over"]:
+            break
+
         moves = api.get_legal_moves()
         for idx, move in enumerate(moves):
             print(f"{idx}: {coords_to_uci(move)}", end="  ")
@@ -32,6 +54,13 @@ while not api.get_state()["over"]:
                 print("Invalid choice, try again.")
             except ValueError:
                 print("Invalid input, enter a number.")
+
+        # LET PLAYER CLAIM DRAW IMMEDIATELY AFTER 3RD REPETITION
+        if api.get_state()["result"] == "threefold_draw_claimable":
+            prompt_draw()
+        if api.get_state()["over"]:
+            break
+
     else:
         print("Engine Thinking...", end="", flush=True)
         move = engine.get_best_move()

--- a/src/backend/api.py
+++ b/src/backend/api.py
@@ -18,6 +18,9 @@ class API:
     def get_legal_moves(self):
         return self.g.legal_moves()
 
+    def claim_threefold_draw(self):
+        return self.g.claim_threefold_draw()
+
     def make_move(self, move):
         return self.g.make_move(move)
 
@@ -26,16 +29,16 @@ class API:
 
     def undo_move(self, move, record):
         return self.g.board.undo_move(move, record)
-    
+
     def undo(self):
         return self.g.undo()
-    
+
     def redo(self):
         return self.g.redo()
-    
+
     def can_undo(self):
         return self.g.can_undo()
-    
+
     def can_redo(self):
         return self.g.can_redo()
 

--- a/src/backend/board.py
+++ b/src/backend/board.py
@@ -1,6 +1,17 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
+from .zobrist import (
+    hash_board,
+    hash_piece,
+    hash_move,
+    hash_en_passant,
+    hash_castle,
+    hash_promotion,
+    hash_turn,
+)
+from .zobrist import WKING_LONG, WKING_SHORT, BKING_LONG, BKING_SHORT, DEFAULT_CASTLING
+
 
 @dataclass
 class MoveRecord:
@@ -10,6 +21,8 @@ class MoveRecord:
     from_sq: Tuple[int, int] = (0, 0)
     to_sq: Tuple[int, int] = (0, 0)
     en_passant: bool = False
+    castling_rights: int = DEFAULT_CASTLING
+    en_passant_file: Optional[int] = None
 
 
 EMPTY = 0
@@ -22,6 +35,10 @@ class Board:
         self.board = self.starting_pos()
         self.wking_pos = (7, 4)
         self.bking_pos = (0, 4)
+
+        self.castling_rights = DEFAULT_CASTLING
+        self.en_passant_file = None
+        self.hash = hash_board(self.board)
 
     def starting_pos(self):
         return [
@@ -37,40 +54,78 @@ class Board:
 
     def apply_move(self, move):
         (fx, fy), (tx, ty) = move
+        # CAPTURED PIECE POSITION
+        (cx, cy) = (tx, ty)
 
         original_piece = self.board[fx][fy]
-
         captured = self.board[tx][ty]
 
         self.board[tx][ty] = original_piece
         self.board[fx][fy] = EMPTY
-
         en_passant = False
 
+        removed_castle_right = 0
+        old_castling_rights = self.castling_rights
+        old_en_passant_file = self.en_passant_file
+        self.en_passant_file = None
+
+        # UPDATE CASTLING RIGHTS IF KING/ROOK MOVE
         if original_piece == WKING:
             self.wking_pos = (tx, ty)
+            removed_castle_right = WKING_LONG | WKING_SHORT
         elif original_piece == BKING:
             self.bking_pos = (tx, ty)
+            removed_castle_right = BKING_LONG | BKING_SHORT
+
+        elif original_piece == WROOK and fx == 7:
+            removed_castle_right = WKING_LONG if fy == 0 else WKING_SHORT
+        elif original_piece == BROOK and fx == 0:
+            removed_castle_right = BKING_LONG if fy == 0 else BKING_SHORT
+
+        # CHECK IF PSEUDO-LEGAL EN PASSANT CAPTURE EXISTS FOR NEXT TURN
+        elif abs(original_piece) == WPAWN and abs(tx - fx) == 2:
+            if (ty <= 6 and self.board[tx][ty + 1] == -original_piece) or (
+                ty >= 1 and self.board[tx][ty - 1] == -original_piece
+            ):
+                self.en_passant_file = fy
 
         # HANDLE EN PASSANT
         elif captured == EMPTY and abs(original_piece) == WPAWN:
             if fy != ty:
-                captured = self.board[tx + abs(original_piece)][ty]
-                self.board[tx + abs(original_piece)][ty] = EMPTY
+                cx = tx + abs(original_piece)
+                captured = self.board[cx][cy]
+                self.board[cx][cy] = EMPTY
                 en_passant = True
+
+        # UPDATE CASTLING RIGHTS IF ROOK CAPTURED
+        if captured == WROOK and tx == 7:
+            if ty == 7:
+                removed_castle_right |= WKING_LONG
+            elif ty == 0:
+                removed_castle_right |= WKING_SHORT
+        elif captured == BROOK and tx == 0:
+            if ty == 7:
+                removed_castle_right |= BKING_LONG
+            elif ty == 0:
+                removed_castle_right |= BKING_SHORT
+
         # HANDLE CASTLING
         # CHECK IF KING MADE A 2SQR MOVE
         if abs(original_piece) == WKING and abs(fy - ty) == 2:
             # SHORT
             if ty == 6:
-                rook = self.board[fx][7]
+                cy = 7
+                rook = self.board[fx][cy]
                 self.board[fx][5] = rook  # move rook
                 self.board[fx][7] = EMPTY  # empty the sqr
+                self.hash = hash_piece(self.hash, rook, (fx, 5))
             # LONG
             elif ty == 2:
-                rook = self.board[fx][0]
+                cy = 0
+                rook = self.board[fx][cy]
                 self.board[fx][3] = rook  # move rook
-                self.board[fx][0] = EMPTY
+                self.board[fx][cy] = EMPTY
+                self.hash = hash_piece(self.hash, rook, (fx, 3))
 
         promotion = None
         if original_piece == WPAWN and tx == 0:
@@ -80,6 +135,17 @@ class Board:
             promotion = BQUEEN
             self.board[tx][ty] = BQUEEN
 
+        self.castling_rights &= ~(removed_castle_right)
+        self.update_hashes(
+            original_piece,
+            move,
+            captured,
+            (cx, cy),
+            old_castling_rights,
+            old_en_passant_file,
+            promotion,
+        )
+
         return MoveRecord(
             moved_piece=original_piece,
             captured_piece=captured,
@@ -87,14 +153,23 @@ class Board:
             from_sq=(fx, fy),
             to_sq=(tx, ty),
             en_passant=en_passant,
+            castling_rights=old_castling_rights,
+            en_passant_file=old_en_passant_file,
         )
 
     def undo_move(self, move, move_record):
         (fx, fy), (tx, ty) = move
+        (cx, cy) = (tx, ty)
         # piece = self.board[tx][ty]
 
         self.board[fx][fy] = move_record.moved_piece
         self.board[tx][ty] = move_record.captured_piece
+
+        old_castling_rights = self.castling_rights
+        old_en_passant_file = self.en_passant_file
+
+        self.castling_rights = move_record.castling_rights
+        self.en_passant_file = move_record.en_passant_file
 
         if move_record.moved_piece == WKING:
             self.wking_pos = (fx, fy)
@@ -104,17 +179,51 @@ class Board:
         if abs(move_record.moved_piece) == WKING and abs(fy - ty) == 2:
             # SHORT
             if ty == 6:
-                rook = self.board[fx][5]
+                cy = 5
+                rook = self.board[fx][cy]
                 self.board[fx][7] = rook  # undo rook
-                self.board[fx][5] = EMPTY
+                self.board[fx][cy] = EMPTY
+                self.hash = hash_piece(self.hash, rook, (fx, 7))
+
             # LONG
             elif ty == 2:
-                rook = self.board[fx][3]
-                self.board[fx][0] = rook  # nudo rook
-                self.board[fx][3] = EMPTY
+                cy = 3
+                rook = self.board[fx][cy]
+                self.board[fx][0] = rook  # undo rook
+                self.board[fx][cy] = EMPTY
+                self.hash = hash_piece(self.hash, rook, (fx, 0))
 
         # ENPASSANT UNDO
         elif move_record.en_passant:
             self.board[tx][ty] = EMPTY
-            rank = tx + abs(move_record.moved_piece)
-            self.board[rank][ty] = move_record.captured_piece
+            cx = tx + abs(move_record.moved_piece)
+            self.board[cx][ty] = move_record.captured_piece
+
+        # RESTORE HASHES
+        self.update_hashes(
+            move_record.moved_piece,
+            (move_record.from_sq, move_record.to_sq),
+            move_record.captured_piece,
+            (cx, cy),
+            old_castling_rights,
+            old_en_passant_file,
+            move_record.promotion,
+        )
+
+    def update_hashes(
+        self,
+        moved_piece,
+        move,
+        captured_piece,
+        captured_position,
+        old_castling_rights,
+        old_en_passant_file,
+        promotion,
+    ):
+        self.hash = hash_move(self.hash, moved_piece, move)
+        self.hash = hash_piece(self.hash, captured_piece, captured_position)
+        self.hash = hash_castle(self.hash, old_castling_rights, self.castling_rights)
+        self.hash = hash_en_passant(self.hash, old_en_passant_file)
+        self.hash = hash_en_passant(self.hash, self.en_passant_file)
+        self.hash = hash_promotion(self.hash, moved_piece, move[1], promotion)
+        self.hash = hash_turn(self.hash)

--- a/src/backend/game.py
+++ b/src/backend/game.py
@@ -1,8 +1,9 @@
+from collections import defaultdict
 from .board import Board
 from .board import WPAWN, WKNIGHT, WBISHOP, WROOK, WQUEEN, WKING
 from .board import BPAWN, BKNIGHT, BBISHOP, BROOK, BQUEEN, BKING, EMPTY
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, DefaultDict
 import copy
 
 from .move_gen import getLegalMoves, isSquareAttacked
@@ -19,6 +20,7 @@ class GameState:
     game_over: bool
     result: Optional[str]
 
+
 class Game:
     def __init__(self):
         self.board = Board()
@@ -26,21 +28,24 @@ class Game:
         self.game_over = False
         self.result = None
         self.halfmove_clock = 0
-        
+
         self.state_stack = []
         self.redo_stack = []
         self.history = []
+        self.hash_history = defaultdict(int)
 
     def is_check(self, color):
         king_pos = self.board.wking_pos if color == "white" else self.board.bking_pos
         return isSquareAttacked(self.board, *king_pos, by_white=(color == "black"))
-
 
     def get_gamestate(self):
         moves = self.legal_moves()
 
         if self.halfmove_clock >= 100:
             return "draw_fifty_move_rule"
+
+        if self.hash_history[self.board.hash] == 3:
+            return "threefold_draw_claimable"
 
         if moves:
             return "ongoing"
@@ -53,7 +58,7 @@ class Game:
 
     def legal_moves(self):
         return getLegalMoves(self.board, self.turn, self.history)
-    
+
     def save_state(self):
         state = GameState(
             board_state=copy.deepcopy(self.board.board),
@@ -62,10 +67,10 @@ class Game:
             turn=self.turn,
             halfmove_clock=self.halfmove_clock,
             game_over=self.game_over,
-            result=self.result
+            result=self.result,
         )
         return state
-    
+
     def restore_state(self, state):
         self.board.board = copy.deepcopy(state.board_state)
         self.board.wking_pos = state.wking_pos
@@ -85,6 +90,7 @@ class Game:
         self.redo_stack.clear()
 
         record = self.board.apply_move(move)
+        self.hash_history[self.board.hash] += 1
         self.history.append(record)
 
         if record.moved_piece in [WPAWN, BPAWN] or record.captured_piece != EMPTY:
@@ -93,25 +99,33 @@ class Game:
             self.halfmove_clock += 1
 
         state = self.get_gamestate()
-        if state != "ongoing":
+        if state == "ongoing" or state == "threefold_draw_claimable":
+            self.turn = "black" if self.turn == "white" else "white"
+            self.result = None if state == "ongoing" else state
+        else:
             self.game_over = True
             self.result = state
-        else:
-            self.turn = "black" if self.turn == "white" else "white"
 
         return record
+
+    def claim_threefold_draw(self):
+        if self.get_gamestate() == "threefold_draw_claimable":
+            self.game_over = True
+            self.result = "draw_threefold_repetition"
+        return self.game_over
 
     def undo(self):
         if not self.state_stack:
             return False
         current_state = self.save_state()
+        self.hash_history[self.board.hash] -= 1
         self.redo_stack.append(current_state)
         previous_state = self.state_stack.pop()
         self.restore_state(previous_state)
         if self.history:
             self.history.pop()
         return True
-    
+
     def redo(self):
         if not self.redo_stack:
             return False
@@ -119,13 +133,14 @@ class Game:
         self.state_stack.append(current_state)
         next_state = self.redo_stack.pop()
         self.restore_state(next_state)
+        self.hash_history[self.board.hash] += 1
         return True
-    
+
     def can_undo(self):
         return len(self.state_stack) > 0
-    
+
     def can_redo(self):
         return len(self.redo_stack) > 0
-    
+
     def undo_last(self):
         return self.undo()

--- a/src/backend/move_gen.py
+++ b/src/backend/move_gen.py
@@ -167,9 +167,7 @@ def getLegalMoves(board, color, history):
 
             for nx, ny in getPseudoLegalMoves(board.board, x, y):
                 move = ((x, y), (nx, ny))
-
                 record = board.apply_move(move)
-
                 king_pos = board.wking_pos if color == "white" else board.bking_pos
                 if not isSquareAttacked(board, *king_pos, by_white=(color == "black")):
                     moves.append(move)
@@ -180,7 +178,6 @@ def getLegalMoves(board, color, history):
 
     for move in getEnPassantMoves(board.board, color, history):
         record = board.apply_move(move)
-
         king_pos = board.wking_pos if color == "white" else board.bking_pos
         if not isSquareAttacked(board, *king_pos, by_white=(color == "black")):
             moves.append(move)

--- a/src/backend/zobrist.py
+++ b/src/backend/zobrist.py
@@ -1,0 +1,79 @@
+import random
+
+from typing import Optional, Tuple, List
+
+WKING_LONG = 1 << 3
+WKING_SHORT = 1 << 2
+BKING_LONG = 1 << 1
+BKING_SHORT = 1 << 0
+DEFAULT_CASTLING = WKING_LONG | WKING_SHORT | BKING_LONG | BKING_SHORT
+
+NUM_SQUARES = 64
+NUM_PIECES = 12
+
+
+zobrist_table = {
+    "pieces": [
+        [random.getrandbits(64) for _ in range(NUM_SQUARES)] for _ in range(NUM_PIECES)
+    ],
+    "turn": random.getrandbits(64),
+    "en-passant": [random.getrandbits(64) for _ in range(8)],
+    "castling": [random.getrandbits(64) for _ in range(4)],
+}
+
+
+def hash_board(board: List[List[int]]):
+    hash = 0
+    for i in range(8):
+        for j in range(8):
+            hash = hash_piece(hash, board[i][j], (i, j))
+    hash = hash_castle(hash, 0, DEFAULT_CASTLING)
+    return hash
+
+
+def hash_turn(hash):
+    return hash ^ zobrist_table["turn"]
+
+
+def hash_piece(hash: int, piece: int, position: Tuple[int, int]):
+    if not piece:
+        return hash
+    # CONVERT PIECE TO INDEX
+    piece = piece + 5 if piece > 0 else piece + 6
+    fx, fy = position
+    randomNum = zobrist_table["pieces"][piece][fx * 8 + fy]
+    return hash ^ randomNum
+
+
+def hash_move(hash: int, piece: int, move: Tuple[Tuple[int, int], Tuple[int, int]]):
+    position1, position2 = move
+    # HASH TWICE TO REMOVE PIECE FROM POSITION1 AND ADD PIECE TO POSITION2
+    return (
+        hash ^ hash_piece(hash, piece, position1) ^ hash_piece(hash, piece, position2)
+    )
+
+
+def hash_castle(hash: int, old: int, new: int):
+    changed_rights = old ^ new
+    if changed_rights == 0:
+        return hash
+
+    # HASH ONLY THE CASTLING RIGHTS THAT HAVE CHANGED
+    for i in range(4):
+        if changed_rights & (1 << i):
+            hash ^= zobrist_table["castling"][i]
+    return hash
+
+
+def hash_en_passant(hash: int, rank: Optional[int]):
+    return hash if rank == None else hash ^ zobrist_table["en-passant"][rank]
+
+
+def hash_promotion(
+    hash: int, piece: int, position: Tuple[int, int], promotion: Optional[int]
+):
+    if not promotion:
+        return hash
+    return (
+        hash ^ hash_piece(hash, piece, position) ^ hash_piece(hash, promotion, position)
+    )


### PR DESCRIPTION
# Feature
Implemented draw by threefold repetition through zobrist hashing. 

- Player can choose to claim draw at the start of their turn when opponent has made the third repetition of a position.
-  Player can also choose to claim draw at the end of their turn just before making the third repetition of a position.
-  Engine can also choose to claim draw through an exposed api route for claiming draw by threefold repetition.
-  Positions are only counted as a repetition when board position is the same, same player to move, same castling rights, and same en-passant capture possibilities 

# Implementation
- Zobrist file generates pseudorandom numbers and defines functions for hashing board position, special moves, etc.
-  Hash is stored in Board and hashing occurs at Board.apply_move(). The same hashes are repeated in Board.undo_move() to undo the hashing
- 'Castling rights' and 'en passant file' are now stored in Board and MoveRecord classes for hashing
- The castling rights hashed into position are the long-term rights. Said castling rights are only modified when a king or rook has moved. Other restrictions are currently not considered for the purpose of calculating repetition as implemented in most engines like [chess.com](https://www.chess.com/analysis/game/pgn/japcZ1ZZp/analysis).
-  The en passant capture possibility is hashed into the board position if a pawn makes a double push and there are adjacent enemy pawns. Other restrictions are currently not considered for calculating repetition. This is the also the same implementation in most engines like [chess.com](https://www.chess.com/analysis/game/pgn/3ajVdKMehC/analysis).
- **NOTE: These stored rights do not affect the legality of making moves. If used to refactor implementation of castling and en passant in the future, take the above into consideration and change accordingly**
- Game class stores zobrist hash history, and returns a threefold draw claimable state when a given hash is 3
- API can exposed route for claiming draw that will end the game if threefold repetition has occured
- Main.py checks game state to see if a draw by threefold repetition is claimable at the start and end of player's turn, prompts player, and then calls the api route for claiming draw if player wishes to do so

# Examples
### Example 1: simple draw accepted start of turn
<img width="319" height="393" alt="image" src="https://github.com/user-attachments/assets/4173b7fc-3272-4a7e-ad40-e658e47df4dc" />
<img width="400" height="401" alt="image" src="https://github.com/user-attachments/assets/fda122a4-bd06-4f31-8b29-7423bf83aa95" />
<img width="350" height="390" alt="image" src="https://github.com/user-attachments/assets/34231bb6-398c-46d8-b754-2c4309ded91e" />
<img width="350" height="410" alt="image" src="https://github.com/user-attachments/assets/79cb2296-f1b3-4ffd-b455-ca483890fecf" />
<img width="640" height="532" alt="image" src="https://github.com/user-attachments/assets/43237145-e4f1-46ae-aa1e-c7f22f95711c" />

_(engine has made the 3rd repetition move, player is prompted start of their turn before making a move)_


<img width="422" height="314" alt="image" src="https://github.com/user-attachments/assets/d8c94640-e576-4c84-9520-caffc692d4ce" />

### Example 2: claim draw at end of turn
<img width="634" height="410" alt="image" src="https://github.com/user-attachments/assets/959c5d4f-6d1b-4969-830a-2e36c6e9d19a" />

_following from previous example, but we reject the draw claim_

<img width="633" height="436" alt="image" src="https://github.com/user-attachments/assets/4085c480-50f5-45a9-b929-531e69126e72" />

_white is trying to play Qf3 again, which would result in a threefold repetition, and is prompted immediately after making the move_

<img width="550" height="344" alt="image" src="https://github.com/user-attachments/assets/f31718b9-a829-4e71-9a88-33f2312645c3" />

### Example 3: Non-consecutive threefold repetition 
<img width="282" height="311" alt="image" src="https://github.com/user-attachments/assets/642a2be1-879c-42e8-986b-719a8de07242" />

_Same as other examples until this move_

<img width="298" height="313" alt="image" src="https://github.com/user-attachments/assets/9de79405-e7e7-448c-9bac-038ae4ffbd95" />

_Note the same board position is reached after white played Qd1, but it isn't threefold because it's a different player's turn_

<img width="293" height="312" alt="image" src="https://github.com/user-attachments/assets/6fd33610-7449-44ec-beed-0af18178e5a0" />
<img width="619" height="337" alt="image" src="https://github.com/user-attachments/assets/0f929bb0-4927-4579-91f6-274a3429d31f" />

_We are prompted for threefold repetition only when it's same board position and same player to move (plus same en-passant/castling rights), and these positions don't necessarily have to be consecutive_